### PR TITLE
Replace standard-version with commit-and-tag-version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,36 @@
 # Changelog
 
-All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
+
+## 1.1.0 (2024-08-12)
+
+
+### Features
+
+* **husky:** implemeted linting with husky ([4710ce3](https://github.com/rinku-samanta-ts/ts-fe-boilerplate/commit/4710ce34511f8c26a9a7906c8e5e6bb9f1773d6f))
+* **release:** revert changes for prettier ([9cc9193](https://github.com/rinku-samanta-ts/ts-fe-boilerplate/commit/9cc9193dcf3ba0370bec6a1764b4bc840a063158))
+* **setup:** checking release note ([07ca160](https://github.com/rinku-samanta-ts/ts-fe-boilerplate/commit/07ca16071c39cb38694d098d60e2072c69c560f7))
+* **setup:** modify branchname pattern ([e0df920](https://github.com/rinku-samanta-ts/ts-fe-boilerplate/commit/e0df920d3ab7d9c512a29f244379c4cbe93da268))
+* **setup:** modify readme.md file ([605e74e](https://github.com/rinku-samanta-ts/ts-fe-boilerplate/commit/605e74e683f689367f3fbf5842c2a17279158213))
+* **setup:** modify readme.md file ([0f61f87](https://github.com/rinku-samanta-ts/ts-fe-boilerplate/commit/0f61f87e6f521f48d2899cfe852cd72a0718dad0))
+* **setup:** modify readme.md file ([fc7b076](https://github.com/rinku-samanta-ts/ts-fe-boilerplate/commit/fc7b076d975a5a4d6bc044a481e9a737e7d1fb09))
+* **setup:** validate env file ([55120c5](https://github.com/rinku-samanta-ts/ts-fe-boilerplate/commit/55120c5f0bec9f42a931cbefad4dcd39ba499f45))
+* **user:** pr changes ([e2fe99f](https://github.com/rinku-samanta-ts/ts-fe-boilerplate/commit/e2fe99fd35366bc320f4a45238818dfca3ff7898))
+* **user:** toggle column and enhancement ([6e11823](https://github.com/rinku-samanta-ts/ts-fe-boilerplate/commit/6e11823ff0b09cacaa4bc5d8542ea923b46302e7))
+* **user:** user list with searching sorting and pagination ([bb407da](https://github.com/rinku-samanta-ts/ts-fe-boilerplate/commit/bb407dacf950da76b499ea5dcecca229cb42089e))
+
+
+### Bug Fixes
+
+* **flow:** check env content on commit ([4dc1999](https://github.com/rinku-samanta-ts/ts-fe-boilerplate/commit/4dc1999eaf6b7d6635b0e3c69396d97273c55e05))
+* **flow:** check env content on commit ([bf162b8](https://github.com/rinku-samanta-ts/ts-fe-boilerplate/commit/bf162b8b95caf0eec62e2b7323b0f95faafcc910))
+* **flow:** check env content on commit ([333654f](https://github.com/rinku-samanta-ts/ts-fe-boilerplate/commit/333654fd3e0890ae946d6f0bf98f51eb0c2dd87c))
+* **linting:**  prettier comma changes ([94aeb5a](https://github.com/rinku-samanta-ts/ts-fe-boilerplate/commit/94aeb5ad17d069c3ca0a75c0ad0642df92c12ba4))
+* **package:** adds missing package in NPM ([066b23c](https://github.com/rinku-samanta-ts/ts-fe-boilerplate/commit/066b23cf5842f8cce87b60c3d801e17c5ce0c6f1))
+* **package:** adds missing package in NPM ([75a79f4](https://github.com/rinku-samanta-ts/ts-fe-boilerplate/commit/75a79f41e06ded90f5cc038e155a3f016e1e79c0))
+* **setup:** remove package-lock.json and neflify ([a7b5e9f](https://github.com/rinku-samanta-ts/ts-fe-boilerplate/commit/a7b5e9ff310b0eb089a3d28ef2623ad15af9fe9b))
+* **validation:** implements validations folder and refactor validation in its own file ([fa954df](https://github.com/rinku-samanta-ts/ts-fe-boilerplate/commit/fa954df1d7c3714aedd5569744c036b775f037ef))
+* **validation:** update rules ([eda149a](https://github.com/rinku-samanta-ts/ts-fe-boilerplate/commit/eda149ab6ed15f48809eb1fa6996ab8fba6feb0d))
 
 ## 1.0.0 (2024-07-05)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "admin",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "start": "vite",
@@ -15,7 +15,7 @@
     "prepare": "husky",
     "lint-staged": "lint-staged",
     "validate-branch": "validate-branch-name",
-    "release": "standard-version"
+    "release": "commit-and-tag-version"
   },
   "lint-staged": {
     "src/**/*.{js,ts,jsx,tsx}": [
@@ -81,6 +81,7 @@
     "@typescript-eslint/parser": "^6.14.0",
     "@vitejs/plugin-react-swc": "^3.6.0",
     "autoprefixer": "^10.4.19",
+    "commit-and-tag-version": "^12.4.1",
     "eslint": "^8.55.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
@@ -89,7 +90,6 @@
     "postcss": "^8.4.38",
     "prettier": "^3.2.5",
     "prettier-plugin-tailwindcss": "^0.5.14",
-    "standard-version": "^9.5.0",
     "tailwindcss": "^3.4.3",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5",


### PR DESCRIPTION
## Description

Replace standard-version with commit-and-tag-version


## Checklist:
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation accordingly.

## Additional Notes

**Reason for Change:**

- `standard-version` has been deprecated, and the maintainers have officially recommended using `commit-and-tag-version` instead due to a lack of active maintainers.
- [GitHub Repository for Reference](https://github.com/conventional-changelog/standard-version)
